### PR TITLE
New Kafka consumer API / Kafka 2.3.1 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,18 @@ ArcGIS GeoEvent Server sample Kafka connectors for connecting to Kafka message s
 
 ![App](kafka-for-geoevent.png?raw=true)
 
+## Changes in this Fork
+
+This branch provides additional capabilities:
+- Upgrade to the new Kafka consumer API and kafka-clients 2.3.1. A Zookeeper connection is no longer required.
+- You can specify custom Kafka configuration parameters like `compression.type`, `linger.ms` and TLS settings. 
+- The names and versions have been changed to reflect a difference from the upstream code.
+
+*This code is provided under the Apache 2.0 license and is not officially maintained or supported by the Esri GeoEvent team.*
+
 ## Features
-* Kafka Inbound Transport
-* Kafka Outbound Transport
+* Kafka Advanced Inbound Transport
+* Kafka Advanced Outbound Transport
 
 ## Instructions
 
@@ -42,7 +51,7 @@ Find a bug or want to request a new feature?  Please let us know by submitting a
 Esri welcomes contributions from anyone and everyone. Please see our [guidelines for contributing](https://github.com/esri/contributing).
 
 ## Licensing
-Copyright 2015 Esri
+Copyright 2019 Esri
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/kafka-transport/pom.xml
+++ b/kafka-transport/pom.xml
@@ -2,20 +2,21 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.esri.geoevent.parent</groupId>
+		<groupId>com.esri.geoevent</groupId>
 		<artifactId>kafka</artifactId>
-		<version>10.5.0</version>
+		<version>1.0</version>
 	</parent>
 	<groupId>com.esri.geoevent.transport</groupId>
-	<artifactId>kafka-transport</artifactId>
-	<name>Esri :: GeoEvent :: Transport :: Kafka</name>
+	<artifactId>kafka-advanced-transport</artifactId>
+	<name>Esri :: GeoEvent :: Kafka (Advanced)</name>
+	<description>
+		Variant of the GeoEvent Kafka Transport supporting additional features. Kafka 0.11 or newer is required.
+	</description>
 	<packaging>bundle</packaging>
 	<dependencies>
 		<dependency>
 			<groupId>com.esri.geoevent.sdk</groupId>
 			<artifactId>geoevent-sdk</artifactId>
-			<version>${project.version}</version>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>log4j</groupId>
@@ -33,12 +34,17 @@
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>
+						<Bundle-Name>Kafka-Advanced</Bundle-Name>
 						<Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
 						<Bundle-ContactAddress>${contact.address}</Bundle-ContactAddress>
 						<Bundle-Version>${project.version}</Bundle-Version>
 						<AGES-Domain>com.esri.geoevent.transport</AGES-Domain>
 						<Export-Package/>
-						<Import-Package>!kafka.*,*</Import-Package>
+						<Import-Package>
+							!com.ibm.security.krb5.internal.*,
+							!sun.security.krb5.*,
+							*
+						</Import-Package>
 						<Private-Package>com.esri.geoevent.transport.kafka</Private-Package>
 					</instructions>
 				</configuration>

--- a/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaComponentBase.java
+++ b/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaComponentBase.java
@@ -30,16 +30,21 @@ import java.util.Observable;
 import java.util.Properties;
 
 abstract class KafkaComponentBase extends Observable implements EventDestinationAwareComponent {
-  EventDestination destination;
   private volatile boolean connected = false;
   private String details = "";
   private int timeout = 10000;
-  Properties props = new Properties();
+
+  final EventDestination destination;
+  final Properties props;
 
   KafkaComponentBase(EventDestination destination) {
-    this.destination = destination;
-  }
+    this(destination, new Properties());
+  };
 
+  KafkaComponentBase(EventDestination destination, Properties properties) {
+    this.destination = destination;
+    this.props = properties;
+  }
   @Override
   public EventDestination getEventDestination() {
     return destination;
@@ -68,9 +73,14 @@ abstract class KafkaComponentBase extends Observable implements EventDestination
 
   @Override
   public synchronized void setup() throws MessagingException {
-    disconnect();
-    init();
-    setConnected();
+    try {
+      disconnect();
+      init();
+      setConnected();
+    }
+    catch(Exception ex) {
+      throw new MessagingException(ex.getMessage());
+    }
   }
 
   @Override

--- a/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaInboundTransportDefinition.java
+++ b/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaInboundTransportDefinition.java
@@ -29,21 +29,32 @@ import com.esri.ges.core.property.PropertyException;
 import com.esri.ges.core.property.PropertyType;
 import com.esri.ges.framework.i18n.BundleLogger;
 import com.esri.ges.framework.i18n.BundleLoggerFactory;
-import com.esri.ges.transport.TransportDefinitionBase;
 import com.esri.ges.transport.TransportType;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 
-public class KafkaInboundTransportDefinition extends TransportDefinitionBase {
+public class KafkaInboundTransportDefinition extends KafkaTransportDefinitionBase {
   private static final BundleLogger	LOGGER	= BundleLoggerFactory.getLogger(KafkaInboundTransportDefinition.class);
 
-  public KafkaInboundTransportDefinition()
+  KafkaInboundTransportDefinition()
   {
     super(TransportType.INBOUND);
     try
     {
-      propertyDefinitions.put("zkConnect", new PropertyDefinition("zkConnect", PropertyType.String, "localhost:2181", "${com.esri.geoevent.transport.kafka-transport.ZKCONNECT_LBL}", "${com.esri.geoevent.transport.kafka-transport.ZKCONNECT_DESC}", true, false));
-      propertyDefinitions.put("numThreads", new PropertyDefinition("numThreads", PropertyType.Integer, "1", "${com.esri.geoevent.transport.kafka-transport.NUM_THREADS_LBL}", "${com.esri.geoevent.transport.kafka-transport.NUM_THREADS_DESC}", true, false));
-      propertyDefinitions.put("topic", new PropertyDefinition("topic", PropertyType.String, "", "${com.esri.geoevent.transport.kafka-transport.TOPIC_LBL}", "${com.esri.geoevent.transport.kafka-transport.TOPIC_DESC}", true, false));
-      propertyDefinitions.put("groupId", new PropertyDefinition("groupId", PropertyType.String, "", "${com.esri.geoevent.transport.kafka-transport.GROUOP_ID_LBL}", "${com.esri.geoevent.transport.kafka-transport.GROUOP_ID_DESC}", true, false));
+      propertyDefinitions.put("numThreads", new PropertyDefinition("numThreads",
+          PropertyType.Integer,
+          "1",
+          "${com.esri.geoevent.transport.kafka-advanced-transport.NUM_THREADS_LBL}",
+          "${com.esri.geoevent.transport.kafka-advanced-transport.NUM_THREADS_DESC}",
+          true,
+          false));
+
+      propertyDefinitions.put("groupId", new PropertyDefinition("groupId",
+          PropertyType.String,
+          "",
+          "${com.esri.geoevent.transport.kafka-advanced-transport.GROUP_ID_LBL}",
+          "${com.esri.geoevent.transport.kafka-advanced-transport.GROUP_ID_DESC}",
+          false,
+          false));
     }
     catch (PropertyException e)
     {
@@ -54,32 +65,20 @@ public class KafkaInboundTransportDefinition extends TransportDefinitionBase {
   }
 
   @Override
-  public String getName()
-  {
-    return "Kafka";
-  }
-
-  @Override
   public String getDomain()
   {
     return "com.esri.geoevent.transport.inbound";
   }
 
   @Override
-  public String getVersion()
-  {
-    return "10.5.0";
-  }
-
-  @Override
   public String getLabel()
   {
-    return "${com.esri.geoevent.transport.kafka-transport.IN_LABEL}";
+    return "${com.esri.geoevent.transport.kafka-advanced-transport.IN_LABEL}";
   }
 
   @Override
   public String getDescription()
   {
-    return "${com.esri.geoevent.transport.kafka-transport.IN_DESC}";
+    return "${com.esri.geoevent.transport.kafka-advanced-transport.IN_DESC}";
   }
 }

--- a/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaInboundTransportService.java
+++ b/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaInboundTransportService.java
@@ -25,17 +25,25 @@
 package com.esri.geoevent.transport.kafka;
 
 import com.esri.ges.core.component.ComponentException;
+import com.esri.ges.core.security.GeoEventServerCryptoService;
+import com.esri.ges.manager.datastore.folder.FolderDataStoreManager;
 import com.esri.ges.transport.Transport;
 import com.esri.ges.transport.TransportServiceBase;
 
 public class KafkaInboundTransportService extends TransportServiceBase
 {
+  private FolderDataStoreManager folderDataStoreManager;
+
   public KafkaInboundTransportService() {
     definition = new KafkaInboundTransportDefinition();
   }
 
   @Override
   public Transport createTransport() throws ComponentException {
-    return new KafkaInboundTransport(definition);
+    return new KafkaInboundTransport(definition, folderDataStoreManager);
+  }
+
+  public void setFolderDataStoreManager(FolderDataStoreManager folderDataStoreManager) {
+    this.folderDataStoreManager = folderDataStoreManager;
   }
 }

--- a/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaOutboundTransportDefinition.java
+++ b/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaOutboundTransportDefinition.java
@@ -31,23 +31,23 @@ import com.esri.ges.framework.i18n.BundleLogger;
 import com.esri.ges.framework.i18n.BundleLoggerFactory;
 import com.esri.ges.transport.TransportDefinitionBase;
 import com.esri.ges.transport.TransportType;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
 
-class KafkaOutboundTransportDefinition extends TransportDefinitionBase {
+class KafkaOutboundTransportDefinition extends KafkaTransportDefinitionBase {
   private static final BundleLogger LOGGER	= BundleLoggerFactory.getLogger(KafkaOutboundTransportDefinition.class);
 
   KafkaOutboundTransportDefinition() {
     super(TransportType.OUTBOUND);
     try {
-        propertyDefinitions.put("bootstrap", new PropertyDefinition("bootstrap", PropertyType.String, "localhost:9092", "${com.esri.geoevent.transport.kafka-transport.BOOTSTRAP_LBL}", "${com.esri.geoevent.transport.kafka-transport.BOOTSTRAP_DESC}", true, false));
-        propertyDefinitions.put("topic", new PropertyDefinition("topic", PropertyType.String, "", "${com.esri.geoevent.transport.kafka-transport.TOPIC_LBL}", "${com.esri.geoevent.transport.kafka-transport.TOPIC_DESC}", true, false));
-        propertyDefinitions.put("partitionKeyTag",
-            new PropertyDefinition(
-                "partitionKeyTag",
-                PropertyType.String,"",
-                "${com.esri.geoevent.transport.kafka-transport.PARTITION_KEY_TAG_LBL}",
-                "${com.esri.geoevent.transport.kafka-transport.PARTITION_KEY_TAG_DESC}",
-                false,
-                false));
+      propertyDefinitions.put("partitionKeyTag",
+          new PropertyDefinition(
+              "partitionKeyTag",
+              PropertyType.String,"TRACK_ID",
+              "${com.esri.geoevent.transport.kafka-advanced-transport.PARTITION_KEY_TAG_LBL}",
+              "${com.esri.geoevent.transport.kafka-advanced-transport.PARTITION_KEY_TAG_DESC}",
+              false,
+              false));
     }
     catch (PropertyException e)
     {
@@ -58,32 +58,20 @@ class KafkaOutboundTransportDefinition extends TransportDefinitionBase {
   }
 
   @Override
-  public String getName()
-  {
-    return "Kafka";
-  }
-
-  @Override
   public String getDomain()
   {
     return "com.esri.geoevent.transport.outbound";
   }
 
   @Override
-  public String getVersion()
-  {
-    return "10.5.0";
-  }
-
-  @Override
   public String getLabel()
   {
-    return "${com.esri.geoevent.transport.kafka-transport.OUT_LABEL}";
+    return "${com.esri.geoevent.transport.kafka-advanced-transport.OUT_LABEL}";
   }
 
   @Override
   public String getDescription()
   {
-    return "${com.esri.geoevent.transport.kafka-transport.OUT_DESC}";
+    return "${com.esri.geoevent.transport.kafka-advanced-transport.OUT_DESC}";
   }
 }

--- a/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaOutboundTransportService.java
+++ b/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaOutboundTransportService.java
@@ -25,17 +25,25 @@
 package com.esri.geoevent.transport.kafka;
 
 import com.esri.ges.core.component.ComponentException;
+import com.esri.ges.core.security.GeoEventServerCryptoService;
+import com.esri.ges.manager.datastore.folder.FolderDataStoreManager;
 import com.esri.ges.transport.Transport;
 import com.esri.ges.transport.TransportServiceBase;
 
 public class KafkaOutboundTransportService extends TransportServiceBase
 {
+  private FolderDataStoreManager folderDataStoreManager;
+
   public KafkaOutboundTransportService() {
     definition = new KafkaOutboundTransportDefinition();
   }
 
   @Override
   public Transport createTransport() throws ComponentException {
-    return new KafkaOutboundTransport(definition);
+    return new KafkaOutboundTransport(definition, folderDataStoreManager);
+  }
+
+  public void setFolderDataStoreManager(FolderDataStoreManager folderDataStoreManager) {
+    this.folderDataStoreManager = folderDataStoreManager;
   }
 }

--- a/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaTransportDefinitionBase.java
+++ b/kafka-transport/src/main/java/com/esri/geoevent/transport/kafka/KafkaTransportDefinitionBase.java
@@ -1,0 +1,92 @@
+package com.esri.geoevent.transport.kafka;
+
+import com.esri.ges.core.property.PropertyDefinition;
+import com.esri.ges.core.property.PropertyException;
+import com.esri.ges.core.property.PropertyType;
+import com.esri.ges.core.security.GeoEventServerCryptoService;
+import com.esri.ges.framework.i18n.BundleLogger;
+import com.esri.ges.framework.i18n.BundleLoggerFactory;
+import com.esri.ges.transport.TransportDefinitionBase;
+import com.esri.ges.transport.TransportType;
+
+/**
+ * Base class for the Kafka Transport Definitions
+ */
+abstract class KafkaTransportDefinitionBase extends TransportDefinitionBase {
+
+    private static final BundleLogger LOGGER = BundleLoggerFactory.getLogger(KafkaTransportDefinitionBase.class);
+
+    public static final String PROPERTY_BOOTSTRAP_SERVER = "bootstrapServer";
+    public static final String PROPERTY_TOPIC = "topic";
+    public static final String PROPERTY_ADVANCED_CONFIGS = "advancedConfigs";
+    public static final String PROPERTY_ADVANCED_CONFIGS_FOLDER = "advancedConfigsFolder";
+    public static final String PROPERTY_ADVANCED_CONFIGS_FILE_NAME = "advancedConfigsFileName";
+
+    KafkaTransportDefinitionBase(TransportType type) {
+        super(type);
+
+        try {
+
+            propertyDefinitions.put(PROPERTY_BOOTSTRAP_SERVER,
+                new PropertyDefinition(PROPERTY_BOOTSTRAP_SERVER,
+                    PropertyType.String,
+                    "localhost:9092",
+                    "${com.esri.geoevent.transport.kafka-advanced-transport.BOOTSTRAP_SERVERS_LBL}",
+                    "${com.esri.geoevent.transport.kafka-advanced-transport.BOOTSTRAP_SERVERS_DESC}",
+                    true,
+                    false));
+
+            propertyDefinitions.put(PROPERTY_TOPIC,
+                new PropertyDefinition(PROPERTY_TOPIC,
+                    PropertyType.String,
+                    "",
+                    "${com.esri.geoevent.transport.kafka-advanced-transport.TOPIC_LBL}",
+                    "${com.esri.geoevent.transport.kafka-advanced-transport.TOPIC_DESC}",
+                    true,
+                    false));
+
+            propertyDefinitions.put(PROPERTY_ADVANCED_CONFIGS,
+                new PropertyDefinition(
+                    PROPERTY_ADVANCED_CONFIGS,
+                    PropertyType.String,
+                    "",
+                    "${com.esri.geoevent.transport.kafka-advanced-transport.ADVANCED_CONFIGS_LBL}",
+                    "${com.esri.geoevent.transport.kafka-advanced-transport.ADVANCED_CONFIGS_DESC}",
+                    "",
+                    "textarea",
+                    false,
+                    false));
+
+            propertyDefinitions.put(PROPERTY_ADVANCED_CONFIGS_FOLDER,
+                new PropertyDefinition(
+                    PROPERTY_ADVANCED_CONFIGS_FOLDER,
+                    PropertyType.FolderDataStore,
+                    "",
+                    "${com.esri.geoevent.transport.kafka-advanced-transport.ADVANCED_CONFIGS_FOLDER_LBL}",
+                    "${com.esri.geoevent.transport.kafka-advanced-transport.ADVANCED_CONFIGS_FOLDER_DESC}",
+                    "",
+                    "",
+                    false,
+                    false));
+
+            propertyDefinitions.put(PROPERTY_ADVANCED_CONFIGS_FILE_NAME,
+                new PropertyDefinition(
+                    PROPERTY_ADVANCED_CONFIGS_FILE_NAME,
+                    PropertyType.String,
+                    "",
+                    "${com.esri.geoevent.transport.kafka-advanced-transport.ADVANCED_CONFIGS_FILE_NAME_LBL}",
+                    "${com.esri.geoevent.transport.kafka-advanced-transport.ADVANCED_CONFIGS_FILE_NAME_DESC}",
+                    "",
+                    "",
+                    false,
+                    false));
+        }
+        catch (PropertyException e) {
+            String errorMsg = LOGGER.translate("TRANSPORT_OUT_INIT_ERROR", e.getMessage());
+            LOGGER.error(errorMsg, e);
+            throw new RuntimeException(errorMsg, e);
+        }
+
+
+    }
+}

--- a/kafka-transport/src/main/resources/OSGI-INF/blueprint/config.xml
+++ b/kafka-transport/src/main/resources/OSGI-INF/blueprint/config.xml
@@ -1,12 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+	<reference id="folderDataStoreManagerService" interface="com.esri.ges.manager.datastore.folder.FolderDataStoreManager"/>
+
 	<bean id="kafkaInboundTransportServiceBean" class="com.esri.geoevent.transport.kafka.KafkaInboundTransportService" activation="eager">
 		<property name="bundleContext" ref="blueprintBundleContext"/>
+		<property name="folderDataStoreManager" ref="folderDataStoreManagerService"/>
 	</bean>
+
 	<service id="kafkaInboundTransportService" ref="kafkaInboundTransportServiceBean" interface="com.esri.ges.transport.TransportService"/>
 
 	<bean id="kafkaOutboundTransportServiceBean" class="com.esri.geoevent.transport.kafka.KafkaOutboundTransportService" activation="eager">
 		<property name="bundleContext" ref="blueprintBundleContext"/>
+		<property name="folderDataStoreManager" ref="folderDataStoreManagerService"/>
 	</bean>
+
 	<service id="kafkaOutboundTransportService" ref="kafkaOutboundTransportServiceBean" interface="com.esri.ges.transport.TransportService"/>
 </blueprint>

--- a/kafka-transport/src/main/resources/com/esri/geoevent/transport/kafka-advanced-transport.properties
+++ b/kafka-transport/src/main/resources/com/esri/geoevent/transport/kafka-advanced-transport.properties
@@ -1,17 +1,31 @@
 # Connection Info
-ZKCONNECT_LBL=Zookeeper Connection String
-ZKCONNECT_DESC=Zookeeper connection string in the form hostname:port/chroot.
-BOOTSTRAP_LBL=Bootstrap Servers
-BOOTSTRAP_DESC=A list of host/port pairs to use for establishing the initial connection to the Kafka cluster.
+BOOTSTRAP_SERVERS_LBL=Bootstrap Servers
+BOOTSTRAP_SERVERS_DESC=A list of host/port pairs to use for establishing the initial connection to the Kafka cluster.
+
 TOPIC_LBL=Topic Name
 TOPIC_DESC=Topic Name
-GROUOP_ID_LBL=Consumer Group Id
-GROUOP_ID_DESC=A string that uniquely identifies a set of consumers within the same consumer group.
+
+GROUP_ID_LBL=Consumer Group Id
+GROUP_ID_DESC=A string that uniquely identifies a set of consumers within the same consumer group. \
+If this value is not set, a GUID will be generated.
+
+ADVANCED_CONFIGS_LBL=Advanced Configs
+ADVANCED_CONFIGS_DESC=Advanced configuration properties can be specified here. These entries override those specified from a file.\
+<ul>\
+    <li><a href="https://kafka.apache.org/documentation/#producerconfigs">Producer Configs</a></li>\
+    <li><a href="https://kafka.apache.org/documentation/#consumerconfigs">Consumer Configs</a></li>\
+</ul>
+ADVANCED_CONFIGS_FOLDER_LBL=Advanced Configs Folder
+ADVANCED_CONFIGS_FOLDER_DESC=Folder path for a consumer/producer configuration file. Sensitive data should be stored here instead of in the configuration text area.
+
+ADVANCED_CONFIGS_FILE_NAME_LBL=Advanced Configs Properties File
+ADVANCED_CONFIGS_FILE_NAME_DESC=File name for a consumer/producer properties file. Sensitive data should be stored here instead of in the configuration text area.
 
 # Inbound Transport Definition
 IN_LABEL=Apache Kafka Inbound Transport
 IN_DESC=JMS Inbound Transport for connecting to Apache Kafka message servers.
 TRANSPORT_IN_INIT_ERROR=Failed to define properties of Apache Kafka inbound transport. Error: {0}.
+
 NUM_THREADS_LBL=Number Of Threads
 NUM_THREADS_DESC=Controls the number of worker threads in the broker to serve requests.
 
@@ -23,12 +37,11 @@ PARTITION_KEY_TAG_LBL=Partition Key Tag
 PARTITION_KEY_TAG_DESC=GeoEvent Tag to use as partition key. Leave empty to use round-robin partitioning.
 
 # Log Messages
-ZKCONNECT_VALIDATE_ERROR=Zookeeper connection string is invalid
 BOOTSTRAP_VALIDATE_ERROR=Bootstrap servers is invalid
 TOPIC_VALIDATE_ERROR=Topic name is invalid
 GROUP_ID_VALIDATE_ERROR=Group Id is invalid
 NUM_THREADS_VALIDATE_ERROR=Number of worker threads in the broker to serve requests is invalid
-KAFKA_SEND_FAILURE_ERROR=Failed to send a message to Apache Kafka
+KAFKA_SEND_FAILURE_ERROR=Failed to send a message to Apache Kafka [ topic={0}, partition={1}, offset={2} ]. Error: {$4}
 CONSUMER_RECOVERY_FAILED=Consumer from channel({0}) failed recovering. Error: {1}.
 NO_MATCHING_TAG_WARNING=Cannot partition by key! GeoEvent definition {0} has no matching tag {1}. Using round-robin.
 KAFKA_SENT_RECORD_DEBUG=Sent record: [ topic={0}, partition={1}, offset={2}, keySize={3}, valSize={4} ]

--- a/kafka-transport/src/main/resources/com/esri/geoevent/transport/kafka-advanced-transport_en.properties
+++ b/kafka-transport/src/main/resources/com/esri/geoevent/transport/kafka-advanced-transport_en.properties
@@ -1,0 +1,48 @@
+# Connection Info
+BOOTSTRAP_SERVERS_LBL=Bootstrap Servers
+BOOTSTRAP_SERVERS_DESC=A list of host/port pairs to use for establishing the initial connection to the Kafka cluster.
+
+TOPIC_LBL=Topic Name
+TOPIC_DESC=Topic Name
+
+GROUP_ID_LBL=Consumer Group Id
+GROUP_ID_DESC=A string that uniquely identifies a set of consumers within the same consumer group. \
+If this value is not set, a GUID will be generated.
+
+ADVANCED_CONFIGS_LBL=Advanced Configs
+ADVANCED_CONFIGS_DESC=Advanced configuration properties can be specified here. These entries override those specified from a file.\
+<ul>\
+    <li><a href="https://kafka.apache.org/documentation/#producerconfigs">Producer Configs</a></li>\
+    <li><a href="https://kafka.apache.org/documentation/#consumerconfigs">Consumer Configs</a></li>\
+</ul>
+ADVANCED_CONFIGS_FOLDER_LBL=Advanced Configs Folder
+ADVANCED_CONFIGS_FOLDER_DESC=Folder path for a consumer/producer configuration file. \
+<a href="https://kafka.apache.org/documentation/#producerconfigs">Producer Configs</a>\
+<a href="https://kafka.apache.org/documentation/#consumerconfigs">Consumer Configs</a>
+ADVANCED_CONFIGS_FILE_NAME_LBL=Advanced Configs Properties File
+ADVANCED_CONFIGS_FILE_NAME_DESC=File name for a consumer/producer properties file. Sensitive data should be stored here instead of in the configuration text area.
+
+# Inbound Transport Definition
+IN_LABEL=Apache Kafka Inbound Transport
+IN_DESC=JMS Inbound Transport for connecting to Apache Kafka message servers.
+TRANSPORT_IN_INIT_ERROR=Failed to define properties of Apache Kafka inbound transport. Error: {0}.
+
+NUM_THREADS_LBL=Number Of Threads
+NUM_THREADS_DESC=Controls the number of worker threads in the broker to serve requests.
+
+# Outbound Transport Definition
+OUT_LABEL=Apache Kafka Outbound Transport
+OUT_DESC=JMS Outbound Transport for connecting to Apache Kafka message servers.
+TRANSPORT_OUT_INIT_ERROR=Failed to define properties of Apache Kafka outbound transport. Error: {0}.
+PARTITION_KEY_TAG_LBL=Partition Key Tag
+PARTITION_KEY_TAG_DESC=GeoEvent Tag to use as partition key. Leave empty to use round-robin partitioning.
+
+# Log Messages
+BOOTSTRAP_VALIDATE_ERROR=Bootstrap servers is invalid
+TOPIC_VALIDATE_ERROR=Topic name is invalid
+GROUP_ID_VALIDATE_ERROR=Group Id is invalid
+NUM_THREADS_VALIDATE_ERROR=Number of worker threads in the broker to serve requests is invalid
+KAFKA_SEND_FAILURE_ERROR=Failed to send a message to Apache Kafka [ topic={0}, partition={1}, offset={2} ]. Error: {$4}
+CONSUMER_RECOVERY_FAILED=Consumer from channel({0}) failed recovering. Error: {1}.
+NO_MATCHING_TAG_WARNING=Cannot partition by key! GeoEvent definition {0} has no matching tag {1}. Using round-robin.
+KAFKA_SENT_RECORD_DEBUG=Sent record: [ topic={0}, partition={1}, offset={2}, keySize={3}, valSize={4} ]

--- a/pom.xml
+++ b/pom.xml
@@ -1,23 +1,31 @@
 <?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>com.esri.geoevent.parent</groupId>
+	<groupId>com.esri.geoevent</groupId>
 	<artifactId>kafka</artifactId>
-	<version>10.5.0</version>
+	<version>1.0</version>
 	<packaging>pom</packaging>
 	<name>Esri :: GeoEvent :: Kafka</name>
+	<description>
+		Variant of the GeoEvent Kafka Transport supporting additional features. Kafka 0.11 or newer is required.
+	</description>
 	<url>http://www.esri.com</url>
 	<properties>
-		<contact.address>geoevent@esri.com</contact.address>
+		<contact.address>contracts@esri.com</contact.address>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.bundle.plugin.version>2.3.6</maven.bundle.plugin.version>
-		<kafka.version>0.10.1.1</kafka.version>
+		<kafka.clients.version>2.3.1</kafka.clients.version>
+		<arcgis.version>10.5.1</arcgis.version>
 	</properties>
 	<modules>
 		<module>kafka-transport</module>
 	</modules>
 	<dependencyManagement>
 		<dependencies>
+			<dependency>
+				<groupId>com.esri.geoevent.sdk</groupId>
+				<artifactId>geoevent-sdk</artifactId>
+				<version>${arcgis.version}</version>
+			</dependency>
 			<dependency>
 				<groupId>commons-logging</groupId>
 				<artifactId>commons-logging</artifactId>
@@ -26,11 +34,6 @@
 		</dependencies>
 	</dependencyManagement>
 	<dependencies>
-		<dependency>
-			<groupId>com.esri.geoevent.sdk</groupId>
-			<artifactId>geoevent-sdk</artifactId>
-			<version>10.5.0</version>
-		</dependency>
 		<dependency>
 			<groupId>com.yammer.metrics</groupId>
 			<artifactId>metrics-core</artifactId>
@@ -59,22 +62,7 @@
 		<dependency>
 			<groupId>org.apache.kafka</groupId>
 			<artifactId>kafka-clients</artifactId>
-			<version>${kafka.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>org.apache.kafka</groupId>
-			<artifactId>kafka_2.11</artifactId>
-			<version>${kafka.version}</version>
-		</dependency>
-		<dependency>
-			<groupId>com.101tec</groupId>
-			<artifactId>zkclient</artifactId>
-			<version>0.8</version>
-		</dependency>
-		<dependency>
-			<groupId>org.scala-lang.modules</groupId>
-			<artifactId>scala-parser-combinators_2.11</artifactId>
-			<version>1.0.5</version>
+			<version>${kafka.clients.version}</version>
 		</dependency>
 	</dependencies>
 	<build>
@@ -84,7 +72,7 @@
 					<groupId>org.apache.felix</groupId>
 					<artifactId>maven-bundle-plugin</artifactId>
 					<extensions>true</extensions>
-					<version>${maven.bundle.plugin.version}</version>
+					<version>4.2.1</version>
 					<configuration>
 						<instructions>
 							<Embed-Dependency>
@@ -94,9 +82,6 @@
 								lz4;scope=compile|runtime;inline=true,
 								snappy-java;scope=compile|runtime;inline=true,
 								kafka-clients;scope=compile|runtime;inline=true,
-								kafka_2.11;scope=compile|runtime;inline=true,
-								zkclient;scope=compile|runtime;inline=true,
-								scala-parser-combinators_2.11;scope=compile|runtime;inline=true
 							</Embed-Dependency>
 						</instructions>
 					</configuration>


### PR DESCRIPTION
- New Consumer API and version change
- Updated the transport name and version to be unique, to avoid conflicts with upstream Kafka connector
- Updated to New Kafka Consumer API and upgraded kafka-client to 2.3.1
- Various enhancements including file-based configuration parameter and better error handling.